### PR TITLE
Add support for markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "react": "^15.4.2",
     "react-grid-system": "^2.6.0",
     "react-helmet": "^4.0.0",
+    "react-markdown": "^2.4.5",
     "smoothscroll": "^0.3.0"
   },
   "devDependencies": {

--- a/styles/_markdown.scss
+++ b/styles/_markdown.scss
@@ -1,0 +1,6 @@
+
+// The Markdown Component wraps paragraphs with p tags (even if there is only one), and wraps it all with a div.
+.md-inline {
+  display: inline;
+  & > p:first-child {display: inline}
+}

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -1,5 +1,6 @@
 @import "normalize";
 @import "colors";
+@import "markdown";
 
 body {
   color: $main;

--- a/templates/Category.js
+++ b/templates/Category.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Markdown from 'react-markdown';
 import { Row, Col, Hidden } from 'react-grid-system';
 
 import './Category.scss';
@@ -7,7 +8,7 @@ import { ico } from '../utils';
 const Category = ({ candidat, category }) => (
   <div className="Category" id={category.id}>
     <h3>
-      <i className={`fa fa-${ico[category.id]}`} aria-hidden="true"></i>
+      <i className={`fa fa-${ico[category.id]}`} aria-hidden="true" />
       {' '}
       {category.title}
     </h3>
@@ -21,7 +22,7 @@ const Category = ({ candidat, category }) => (
               <div className="ref">
                 Dans {item.them.ref} ( <a href={item.them.link} target="_blank">source</a> )
               </div>
-              <blockquote>{item.them.quote}</blockquote>
+              <blockquote><Markdown className="md-inline" source={item.them.quote} /></blockquote>
             </div>
           </Col>
           <Col md={6}>
@@ -29,7 +30,7 @@ const Category = ({ candidat, category }) => (
               <div className="ref">
                 Dans {item.us.ref} ( <a href={item.us.link} target="_blank">source</a> )
               </div>
-              <blockquote>{item.us.quote}</blockquote>
+              <blockquote><Markdown className="md-inline" source={item.us.quote} /></blockquote>
             </div>
           </Col>
         </Hidden>
@@ -37,17 +38,15 @@ const Category = ({ candidat, category }) => (
       <Row>
         <Col md={6}>
           <div className="candidat">Avec {candidat}</div>
-          <div
-            className="tldr"
-            dangerouslySetInnerHTML={{ __html: `<i class="fa fa-arrow-circle-right" aria-hidden="true"></i> ${item.them.tldr}` }}
-          />
+          <div className="tldr">
+            <i className="fa fa-arrow-circle-right" aria-hidden="true" /> <Markdown className="md-inline" source={item.them.tldr} />
+          </div>
         </Col>
         <Col md={6}>
           <div className="candidat">Avec Jean-Luc Mélenchon</div>
-          <div
-            className="tldr"
-            dangerouslySetInnerHTML={{ __html: `<i class="fa fa-arrow-circle-right" aria-hidden="true"></i> ${item.us.tldr}` }}
-          />
+          <div className="tldr">
+            <i className="fa fa-arrow-circle-right" aria-hidden="true" /> <Markdown className="md-inline" source={item.us.tldr} />
+          </div>
         </Col>
       </Row>
     </div>

--- a/templates/Category.scss
+++ b/templates/Category.scss
@@ -60,6 +60,10 @@
       font-size: 14px;
       padding: 0 20px;
     }
+
+    strong {
+      color: darken($main, 20);
+    }
   }
 
   .ref {


### PR DESCRIPTION
Allows markdown in `quote` and `tldr`attributes of each item of `[[categories.list]]`.

Should be ready to merge in current master.
